### PR TITLE
chore: use fallbackLng isntead of supportedLngs

### DIFF
--- a/examples/custom-language-selection/components/header.js
+++ b/examples/custom-language-selection/components/header.js
@@ -1,5 +1,8 @@
 import { useTranslation } from 'react-i18next'
 
+/**
+ * Manually change the language and store the selected on localStorage
+ */
 const changeLanguage = (i18n, language) => {
   window.localStorage.setItem('MY_LANGUAGE', language)
   i18n.changeLanguage(language)

--- a/examples/custom-language-selection/next.config.js
+++ b/examples/custom-language-selection/next.config.js
@@ -1,3 +1,6 @@
 module.exports = {
+  /**
+   * No need to setup `i18n` as you will handle the locale yourself
+   */
   reactStrictMode: true,
 }

--- a/examples/custom-language-selection/ni18n.config.js
+++ b/examples/custom-language-selection/ni18n.config.js
@@ -1,10 +1,12 @@
 const supportedLngs = ['en', 'es', 'pt']
 
 export const ni18nConfig = {
-  fallbackLng: 'en',
+  /**
+   * Set `fallbackLng` to the `supportedLngs` array in order for them all to be loaded
+   */
+  fallbackLng: supportedLngs,
   supportedLngs,
   ns: ['alternate', 'home', 'translation'],
-  preload: supportedLngs,
   react: {
     useSuspense: false,
   },

--- a/src/load-translations/get-fallback-locales.test.ts
+++ b/src/load-translations/get-fallback-locales.test.ts
@@ -1,15 +1,7 @@
 import { getFallbackLocales } from './get-fallback-locales'
 
-it('should return supportedLngs when initialLocale is undefined', () => {
-  const result = getFallbackLocales(undefined, {
-    supportedLngs: ['test', 'language'],
-  })
-
-  expect(result).toStrictEqual(['test', 'language'])
-})
-
 it('should return fallbackLng if it is a string', () => {
-  const result = getFallbackLocales('en-test', {
+  const result = getFallbackLocales({
     fallbackLng: 'test',
   })
 
@@ -17,7 +9,7 @@ it('should return fallbackLng if it is a string', () => {
 })
 
 it('should return fallbackLng if it is an array', () => {
-  const result = getFallbackLocales('en-test', {
+  const result = getFallbackLocales({
     fallbackLng: ['test', 'language'],
   })
 
@@ -25,7 +17,7 @@ it('should return fallbackLng if it is an array', () => {
 })
 
 it('should return flattened values of fallbackLng if it is an object', () => {
-  const result = getFallbackLocales('en-test', {
+  const result = getFallbackLocales({
     fallbackLng: {
       test: ['test', 'test2'],
       language: ['language'],
@@ -36,7 +28,7 @@ it('should return flattened values of fallbackLng if it is an object', () => {
 })
 
 it('should return empty array if fallbackLng is null', () => {
-  const result = getFallbackLocales('en-test', {
+  const result = getFallbackLocales({
     // @ts-expect-error testing behavior
     fallbackLng: null,
   })

--- a/src/load-translations/get-fallback-locales.ts
+++ b/src/load-translations/get-fallback-locales.ts
@@ -1,11 +1,6 @@
 import { InitOptions } from 'i18next'
 
-export const getFallbackLocales = (
-  initialLocale: string | undefined,
-  options: InitOptions,
-): string[] => {
-  if (!initialLocale && options.supportedLngs) return [...options.supportedLngs]
-
+export const getFallbackLocales = (options: InitOptions): string[] => {
   const { fallbackLng } = options
   if (typeof fallbackLng === 'string') return [fallbackLng]
   if (Array.isArray(fallbackLng)) return [...fallbackLng]

--- a/src/load-translations/load-translations.test.ts
+++ b/src/load-translations/load-translations.test.ts
@@ -55,9 +55,9 @@ it('should return correct values when namespace is an array', async () => {
   })
 })
 
-it('should return correct values when there is no initialLocale but options.supportedLngs is set', async () => {
+it('should return correct values when there is no initialLocale but options.fallbackLng is set', async () => {
   const result = await loadTranslations(
-    { lng: 'test', supportedLngs: ['test', 'language'] },
+    { lng: 'test', fallbackLng: ['test', 'language'] },
     undefined,
     'ns1',
   )
@@ -82,7 +82,7 @@ it('should return an empty resource object if there is no data', async () => {
     init: Promise.resolve(),
   })
   const result = await loadTranslations(
-    { lng: 'test', supportedLngs: ['test', 'language'] },
+    { lng: 'test', fallbackLng: ['test', 'language'] },
     undefined,
     'ns1',
   )

--- a/src/load-translations/load-translations.ts
+++ b/src/load-translations/load-translations.ts
@@ -54,10 +54,9 @@ export const loadTranslations = async (
 
   const locales = Array.from(
     new Set(
-      [
-        initialLocale,
-        ...getFallbackLocales(initialLocale, i18nextOptions),
-      ].filter(Boolean) as string[],
+      [initialLocale, ...getFallbackLocales(i18nextOptions)].filter(
+        Boolean,
+      ) as string[],
     ),
   )
 


### PR DESCRIPTION
# Description

- use `fallbackLng` isntead of `supportedLngs` when locale is undefined
- added better documentation for `custom-language-selection` example

## Tasks

- [x] Added documentation
- [x] Added tests

<!-- Remember to reference any issue this PR might close -->
