### PR TITLE
feature: target es5 instead of es6

### DIFF
--- a/examples/typescript/next-env.d.ts
+++ b/examples/typescript/next-env.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="next" />
-/// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited

--- a/examples/typescript/next.config.js
+++ b/examples/typescript/next.config.js
@@ -1,3 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ **/
 module.exports = {
   i18n: {
     defaultLocale: 'en',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "skipLibCheck": true,
     "strict": true,
     "strictNullChecks": true,
-    "target": "es2015",
+    "target": "es5",
     "outDir": "dist/esm",
     "declaration": true,
     "downlevelIteration": true
@@ -19,7 +19,8 @@
   "exclude": ["examples/**/*", "data/example-template/**/*"],
   "ts-node": {
     "compilerOptions": {
-      "module": "CommonJS"
+      "module": "CommonJS",
+      "target": "esnext"
     }
   }
 }


### PR DESCRIPTION
# Description

- Target es5 instead of es6 in order to help users who target IE11

## Tasks

- [ ] Added documentation
- [ ] Added tests

<!-- Remember to reference any issue this PR might close -->
#47 
