### PR TITLE
Fix: Use constant for default paths so NextJS can resolve default translation path

### DIFF
--- a/src/common/default-paths.ts
+++ b/src/common/default-paths.ts
@@ -1,5 +1,3 @@
-export const defaultPaths = {
-  public: '/public',
-  locales: '/locales',
-  file: '/{{lng}}/{{ns}}.json',
-}
+export const defaultPublicPath = '/public'
+export const defaultLocalesPath = '/locales'
+export const defaultFilePath = '/{{lng}}/{{ns}}.json'

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -5,4 +5,8 @@ export type { NamespacesNeeded } from './namespaces-needed'
 export { getNamespaces } from './get-namespaces'
 export { uniqueArray } from './unique-array'
 export { isBrowser } from './is-browser'
-export { defaultPaths } from './default-paths'
+export {
+  defaultFilePath,
+  defaultLocalesPath,
+  defaultPublicPath,
+} from './default-paths'

--- a/src/common/ni18n-options.ts
+++ b/src/common/ni18n-options.ts
@@ -6,13 +6,4 @@ export type Ni18nOptions = InitOptions & {
    * @default undefined
    */
   use?: Parameters<I18NextClient['use']>[0][]
-  /**
-   * The root folder that contains all the translation files.
-   * Eg: `/public/translations`
-   *
-   * __Only necessary if you are encountering issues when deploying to Vercel.__
-   *
-   * @default undefined
-   */
-  translationsFolder?: string
 }

--- a/src/create-i18n-instance/get-backend-config.ts
+++ b/src/create-i18n-instance/get-backend-config.ts
@@ -1,5 +1,10 @@
 import { InitOptions } from 'i18next'
-import { defaultPaths, isBrowser } from '../common'
+import {
+  defaultFilePath,
+  defaultLocalesPath,
+  defaultPublicPath,
+  isBrowser,
+} from '../common'
 
 export const getBackendConfig = (
   options: InitOptions,
@@ -15,9 +20,9 @@ export const getBackendConfig = (
       backend: {
         loadPath: path.join(
           process.cwd(),
-          defaultPaths.public,
-          defaultPaths.locales,
-          defaultPaths.file,
+          defaultPublicPath,
+          defaultLocalesPath,
+          defaultFilePath,
         ),
       },
     }
@@ -26,7 +31,7 @@ export const getBackendConfig = (
   if (isBrowser() && !hasCustomBackend) {
     return {
       backend: {
-        loadPath: `${defaultPaths.locales}${defaultPaths.file}`,
+        loadPath: `${defaultLocalesPath}${defaultFilePath}`,
       },
     }
   }

--- a/src/load-translations/ensure-files-load.browser.test.ts
+++ b/src/load-translations/ensure-files-load.browser.test.ts
@@ -11,9 +11,7 @@ beforeAll(() => {
 })
 
 it('should return early and not call anything when in browser', async () => {
-  const translationFolder = '/test/folder'
-
-  await ensureFilesLoad(translationFolder)
+  await ensureFilesLoad()
 
   expect(joinMock).not.toHaveBeenCalled()
 })

--- a/src/load-translations/ensure-files-load.test.ts
+++ b/src/load-translations/ensure-files-load.test.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 import { ensureFilesLoad } from './ensure-files-load'
-import { defaultPaths } from '../common'
+import { defaultLocalesPath, defaultPublicPath } from '../common'
 
 const joinMock = jest.spyOn(path, 'join')
 
@@ -8,19 +8,11 @@ beforeAll(() => {
   jest.clearAllMocks()
 })
 
-it('should use translationsFolder when present', async () => {
-  const translationFolder = '/test/folder'
-
-  await ensureFilesLoad(translationFolder)
-
-  expect(joinMock).toHaveBeenCalledWith(process.cwd(), translationFolder)
-})
-
 it('should use the defaultPaths when there is no translationFolder set', async () => {
   await ensureFilesLoad()
   expect(joinMock).toHaveBeenCalledWith(
     process.cwd(),
-    defaultPaths.public,
-    defaultPaths.locales,
+    defaultPublicPath,
+    defaultLocalesPath,
   )
 })

--- a/src/load-translations/ensure-files-load.ts
+++ b/src/load-translations/ensure-files-load.ts
@@ -1,20 +1,13 @@
-import { isBrowser, defaultPaths } from '../common'
-
-const decidePath = (translationsFolder?: string): string[] => {
-  if (translationsFolder) return [translationsFolder]
-  return [defaultPaths.public, defaultPaths.locales]
-}
+import { defaultLocalesPath, defaultPublicPath, isBrowser } from '../common'
 
 /**
  * We need this to force Vercel to move the files into the runner
  * https://github.com/vercel/next.js/issues/33133
  */
-export const ensureFilesLoad = async (translationsFolder?: string) => {
+export const ensureFilesLoad = async () => {
   if (isBrowser()) return
 
-  const pathToLoad = decidePath(translationsFolder)
+  const { join } = await import('path')
 
-  const path = await import('path')
-
-  path.join(process.cwd(), ...pathToLoad)
+  join(process.cwd(), defaultPublicPath, defaultLocalesPath)
 }

--- a/src/load-translations/load-translations.ts
+++ b/src/load-translations/load-translations.ts
@@ -39,9 +39,9 @@ export const loadTranslations = async (
     throw new Error('No `options` passed to loadTranslations')
   }
 
-  const { use: plugins, translationsFolder, ...i18nextOptions } = options
+  const { use: plugins, ...i18nextOptions } = options
 
-  await ensureFilesLoad(translationsFolder)
+  await ensureFilesLoad()
 
   const { instance, init } = createI18nInstance(
     {


### PR DESCRIPTION
# Description

Tentative fix to force Vercel to load at least the default translations location

## Tasks

- [ ] Added documentation
- [x] Added tests

<!-- Remember to reference any issue this PR might close -->
